### PR TITLE
Softserv dev

### DIFF
--- a/hydra/app/indexers/indexer.rb
+++ b/hydra/app/indexers/indexer.rb
@@ -1,6 +1,8 @@
 class Indexer < ActiveFedora::IndexingService
   def generate_solr_document
     super.tap do |solr_doc|
+      solr_doc['has_image_file_bsi'] = object.image_file.present?
+      solr_doc['has_thumbnail_file_bsi'] = object.thumbnail_file.present?
       add_date(solr_doc)
     end
   end

--- a/hydra/app/jobs/generate_image_thumbs_job.rb
+++ b/hydra/app/jobs/generate_image_thumbs_job.rb
@@ -3,42 +3,24 @@ class GenerateImageThumbsJob < ApplicationJob
 
   queue_as :import
 
-  def perform(identifier)
-    # find record
-    record = Acda.where(identifier: identifier).first
+  def perform(id, download_path)
+    return unless File.exist? download_path
 
+    # find record
+    record = Acda.where(id: id).first
     # temp folder to store images
     image_path = "/home/hydra/tmp/images"
 
     # make folder if it doesn't exist
     FileUtils.mkdir_p(image_path) unless File.exist?(image_path)
 
-    # add identifier and extension to image path so we have
+    # add id and extension to image path so we have
     # full path and file name to image file.
-    image_path = "#{image_path}/#{identifier}.jpg"
-
-    begin
-      # download image file from preview url
-      image_file = URI.open(record.preview)
-    rescue Errno::ENOENT => e
-      Rails.logger.error "Error: edm:preview for #{identifier} is not a valid image url. #{e.message}"
-      return record.thumbnail_file = nil
-    end
-
-    tempfile = File.new(image_path, "w+")
-    IO.copy_stream(image_file, image_path)
-    tempfile.close
-
-    # check if the tempfile is indeed an image
-    mime_type = `file --brief --mime-type #{Shellwords.escape(image_path)}`.strip
-
-    # sets thumbnail_file and image_file to nil if mime_type is not an image
-    # so we don't retain the previous thumbnail and image
-    unless mime_type.include?('image')
-      record.thumbnail_file = nil
-      record.image_file = nil
-      return
-    end
+    image_path = "#{image_path}/#{id}.jpg"
+    # moves the already downloaded file to the expected path
+    FileUtils.mv(download_path, image_path)
+    # create folder if it doesn't exist
+    FileUtils.mkdir_p(image_path) unless File.exist?(image_path)
 
     record.files.build unless record.files.present?
 
@@ -59,14 +41,14 @@ class GenerateImageThumbsJob < ApplicationJob
         # add page to be converted
         convert << image_path
         # add path of page to be converted
-        convert << "#{thumbnail_path}/#{identifier}.jpg"
+        convert << "#{thumbnail_path}/#{id}.jpg"
       end
     end
 
     # check and see if thumbnail exists
-    if File.exist?("#{thumbnail_path}/#{identifier}.jpg")
+    if File.exist?("#{thumbnail_path}/#{id}.jpg")
       # set thumbnail file
-      ImportLibrary.set_file(record.build_thumbnail_file, 'application/jpg', "#{thumbnail_path}/#{identifier}.jpg")
+      ImportLibrary.set_file(record.build_thumbnail_file, 'application/jpg', "#{thumbnail_path}/#{id}.jpg")
     end
 
     record.save!
@@ -78,14 +60,13 @@ class GenerateImageThumbsJob < ApplicationJob
     File.delete(image_path) if File.exist?(image_path)
 
     # delete thumbnails with identifer
-    Dir.glob("#{image_path}/#{identifier}*").each do |file|
+    Dir.glob("#{image_path}/#{id}*").each do |file|
       File.delete(file)
     end
 
     # delete thumbnails with identifer
-    Dir.glob("#{thumbnail_path}/#{identifier}*").each do |file|
+    Dir.glob("#{thumbnail_path}/#{id}*").each do |file|
       File.delete(file)
     end
   end
-
 end

--- a/hydra/app/jobs/generate_thumbs_job.rb
+++ b/hydra/app/jobs/generate_thumbs_job.rb
@@ -1,27 +1,57 @@
 class GenerateThumbsJob < ApplicationJob
   queue_as :import
 
-  def perform(identifier)
+  # we are passing in the Fedora object's id instead of identifier
+  # because the identifier can have special characters which will be
+  # problematic in file and folder creation
+  def perform(id)
     # find record
-    record = Acda.where(identifier: identifier).first
-
+    record = Acda.where(id: id).first
     # Ignore if record type is sound or moving image
     return if record.dc_type.nil?
     return if ((record.dc_type == 'Sound') || (record.dc_type.include? 'Moving'))
+    return unset_image_and_thumbnail!(record) if record.preview.blank?
 
-    if record.preview.blank?
-      record.thumbnail_file = nil
-      record.image_file = nil
-      return
+    # temp folder to store downloaded files
+    file_path = "/home/hydra/tmp/download"
+
+    # make folder if it doesn't exist
+    FileUtils.mkdir_p(file_path) unless File.exist?(file_path)
+
+    # add id to file path so we have full path and file name.
+    download_path = "#{file_path}/#{id}"
+
+    begin
+      # download file from preview url
+      file = URI.open(record.preview)
+    rescue Errno::ENOENT => e
+      Rails.logger.error "Error: edm:preview for #{record.identifier} is not a valid resource url. #{e.message}"
+      return unset_image_and_thumbnail!(record)
     end
 
-    # if record.preview is a pdf
-    if record.preview.include? 'pdf'
-      GeneratePdfThumbsJob.perform_later(identifier)
-    # tesing thumbnail generation for images from remote files
+    tempfile = File.new(download_path, "w+")
+    IO.copy_stream(file, download_path)
+    tempfile.close
+
+    # check if the tempfile is indeed a pdf or image
+    mime_type = `file --brief --mime-type #{Shellwords.escape(download_path)}`.strip
+
+    # sets thumbnail_file and image_file to nil if mime_type is not a pdf or image
+    # so we don't retain the previous thumbnail_file and image_file
+    if mime_type.include?('pdf')
+      GeneratePdfThumbsJob.perform_later(id, download_path)
+    elsif mime_type.include?('image')
+      GenerateImageThumbsJob.perform_later(id, download_path)
     else
-      GenerateImageThumbsJob.perform_later(identifier)
+      return unset_image_and_thumbnail!(record)
     end
   end
 
+  private
+
+    def unset_image_and_thumbnail!(record)
+      record.thumbnail_file = nil
+      record.image_file = nil
+      record.update_index
+    end
 end

--- a/hydra/app/models/acda.rb
+++ b/hydra/app/models/acda.rb
@@ -16,7 +16,7 @@ class Acda < ActiveFedora::Base
 
   def generate_thumbnail
     # queue job to generate thumbnail
-    GenerateThumbsJob.perform_later(identifier)
+    GenerateThumbsJob.perform_later(id)
   end
 
   def clear_empty_fields

--- a/hydra/app/models/solr_document.rb
+++ b/hydra/app/models/solr_document.rb
@@ -78,6 +78,14 @@ class SolrDocument
     fetch('language', []).map { |l| BlacklightOaiProvider::Set.new("language:#{l}") }
   end
 
+  def image_file?
+    self['has_image_file_bsi']
+  end
+
+  def thumbnail_file?
+    self['has_thumbnail_file_bsi']
+  end
+
   private
 
     # Check if a given string is a URL

--- a/hydra/app/views/catalog/_document.html.erb
+++ b/hydra/app/views/catalog/_document.html.erb
@@ -1,25 +1,25 @@
-<% if params[:q].present? 
+<% if params[:q].present?
      @page_title = t('blacklight.search.page_title.title', :constraints => render_search_to_page_title(params), :application_name => application_name)
    else
 	 @page_title = "Browsing #{application_name}"
-   end 
+   end
 %>
 
 <% # container for a single doc -%>
 <div class="document <%= render_document_class document %>" itemscope itemtype="<%= document.itemtype %>">
 	<div class="document-wrap">
-        <% identifier = document[:id] %>
+    <% id = document[:id] %>
 		<% description = document[:description_tesim].to_s %>
 		<% if document[:dc_type_ssi] == "Sound" %>
 			<%= link_to_document document, render(:partial => 'audio_button'), class: "button audio-button" %>
 		<% elsif "Moving".in? document[:dc_type_ssi] %>
 			<%= link_to_document document, render(:partial => 'video_button'), class: "button video-button" %>
-		<% elsif Acda.where(identifier: identifier).first&.image_file.nil? && document[:dc_type_ssi] == "Text" %>
+		<% elsif (document.image_file? == false) && (document[:dc_type_ssi] == "Text") %>
 			<%= link_to_document document, render(:partial => 'pdf_button'), class: "button pdf-button" %>
-		<% else %>   
-			<%= link_to_document document, image_tag("/thumb/#{identifier}", title:"#{document[:title_ssi]}", alt:description) %>
+		<% else %>
+			<%= link_to_document document, image_tag("/thumb/#{id}", title:"#{document[:title_ssi]}", alt:description) %>
 		<% end %>
-		
+
 		<div style="clear:both !important;"></div>
 
 	    <%= render_document_partials(document, blacklight_config.view_config(document_index_view_type).partials, :document_counter => document_counter).html_safe %>

--- a/hydra/app/views/catalog/_pdf.html.erb
+++ b/hydra/app/views/catalog/_pdf.html.erb
@@ -1,19 +1,19 @@
 <%# Ruby Page Variables %>
-<% identifier = @document[:id] %>
+<% id = @document[:id] %>
 <% project = @document[:project_ssi] %>
 <% num_files = @document[:num_files_isi] %>
 <% description = @document[:description_tesim] %>
 <% preview = @document[:preview_ssi] %>
 
 <div class="row">
-  <div class="col-md-4">      
+  <div class="col-md-4">
       <a class="document-image-full" href="<%= preview %>">
-        <% if Acda.where(identifier: identifier).first&.thumbnail_file.nil? %>
+        <% if @document.thumbnail_file? == false %>
           <span class="fa fa-file-pdf-o fa-5x" aria-hidden="true"></span>
         <% else %>
-          <%= image_tag("/image/#{identifier}", title:"#{@document[:title_ssi]}", alt:description, class:"full-size-responsive") %> 
+          <%= image_tag("/image/#{id}", title:"#{@document[:title_ssi]}", alt:description, class:"full-size-responsive") %>
         <% end %>
-        <br><br> 
+        <br><br>
         <span class="fa fa-file-pdf-o"> Click on the image to view full PDF.</span>
       </a>
   </div>


### PR DESCRIPTION
## 🐛 Fix URI identifiers and URI's without `pdf`

a364ea16c1c4e34670aced60c1ccdac7c80c5f9f

This commit will modify the lookup logic for the record based on the id
instead of the identifier.  The problem was because now that we are
accepting url identifiers, the directories and filenames that are based
of off identifiers are not valid for url identifiers because they
contain invalid characters.  Since ids are already sanitized for special
characters, we will use those instead to make valid directory and
file names.

Also in this commit we move the MIME type check logic into the
`GenerateThumbsJob` so we can determine what type of file we are
downloading prior to picking a thumbnail generator.  Checking the MIME
type is more durable than checking the string of the URI.

## 🐛 Move database calls out of the views

5e1fea326d9c57d4de37e6776982665a0326546a

This commit will fix a bug where the id was saved as the identifier.
Though not truly a bug but more of a misnomer, it however did affect URI
identifiers because identifiers were not the same as the id in this
case.

This commit will also add a new indexed field to check weather or not
the record has a thumbnail or image file.  This logic will allow us to
move away from the database call in the view and instead leverage the
Solr Document.

