### PR TITLE
Fix error messages during CSV upload

### DIFF
--- a/hydra/app/services/validation_service.rb
+++ b/hydra/app/services/validation_service.rb
@@ -132,7 +132,7 @@ class ValidationService
 
   def validate_free_text
     values.each do |value|
-      add_error("Missing required value") if value.empty?
+      add_error(value: value, message: "Missing required value") if value.empty?
     end
   end
 


### PR DESCRIPTION
# Fixed validation for validate_free_text

Refs:

# Expected Behavior Before Changes
When validating free text in a csv, validation errors are sent without a required message.

# Expected Behavior After Changes
When validating free text in a csv, validation errors are sent with a required message preventing an error

