### PR TITLE
Add HTML preview to link Archived Site

### DIFF
--- a/hydra/app/helpers/application_helper.rb
+++ b/hydra/app/helpers/application_helper.rb
@@ -49,6 +49,8 @@ module ApplicationHelper
       link_to_document document, render(partial: 'catalog/video_button'), class: "button video-button"
     elsif !document.image_file? && document[:dc_type_ssi] == "Text"
       link_to_document document, render(partial: 'catalog/pdf_button'), class: "button pdf-button"
+    elsif document[:dc_type_ssi] == "Interactive Resource" || document[:dc_type_ssi] == "InteractiveResource"
+      link_to_document document, render(partial: 'catalog/interactive_button'), class: "button interactive-button"
     else
       link_to_document document, render(partial: 'catalog/image_slash'), class: "button image-slash"
     end

--- a/hydra/app/views/catalog/_interactive.html.erb
+++ b/hydra/app/views/catalog/_interactive.html.erb
@@ -1,0 +1,31 @@
+
+<% id = @document[:id] %>
+<% available = @document[:available_at_ssi] %>
+<% title = @document[:title_ssi] %>
+<% description = @document[:description_tesim]&.first || "Interactive content preview" %>
+
+<div class="row">
+  <div class="col-lg-4 text-center">
+    <a class="document-image-full" href="<%= available %>" target="_blank" style="text-decoration: none;">
+      <div style="border: 1px solid #ccc; border-radius: 8px; padding: 15px; background-color: #f8f9fa; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
+        <div style="font-size: 48px; color: #17a2b8;">
+          <i class="fa fa-globe"></i>
+        </div>
+
+
+        <div style="margin-top: 10px; font-size: 13px; color: #007bff;">
+          <i class="fa fa-external-link-alt"></i> Click to open Archived Site
+        </div>
+      </div>
+    </a>
+  </div>
+
+  <div class="col-lg-8">
+    <div id="document" class="document <%= render_document_class %>" itemscope itemtype="<%= @document.itemtype %>">
+      <div id="doc_<%= @document.id.to_s.parameterize %>">
+        <%= render_document_partials(@document, blacklight_config.view_config(:show).partials).html_safe %>
+      </div>
+    </div>
+  </div>
+</div>
+

--- a/hydra/app/views/catalog/_interactive_button.html.erb
+++ b/hydra/app/views/catalog/_interactive_button.html.erb
@@ -1,0 +1,5 @@
+<div class="interactive-button">
+  <span class="fa fa-window-restore fa-5x" aria-hidden="true"></span>
+  <br/>
+  <span class="text"> View Archived Site</span>
+</div>

--- a/hydra/app/views/catalog/show.html.erb
+++ b/hydra/app/views/catalog/show.html.erb
@@ -12,6 +12,8 @@
     <%= render 'previous_next_doc' %>
   </div>
 
+
+
   <% if @document[:dc_type_ssi] == "Image" || @document[:dc_type_ssi] == "Collection" || @document[:dc_type_ssi] == "StillImage"%>
     <%= render 'image' %>
   <% elsif @document[:dc_type_ssi] == "Text" %>
@@ -20,6 +22,11 @@
     <%= render 'audio' %>
   <% elsif @document[:dc_type_ssi] == "Moving Image" || @document[:dc_type_ssi] == "MovingImage"%>
     <%= render 'video' %>
+    
+  <% elsif @document[:dc_type_ssi] == "Interactive Resource" || @document[:dc_type_ssi] == "InteractiveResource" %>
+  <%= render 'interactive' %>
+
+
   <% end %>
 
   <% if @document.respond_to?(:export_as_openurl_ctx_kev) %>


### PR DESCRIPTION
Added support for HTML preview in interactive resource records.
- Displayed a custom icon and message for Interactive Resource type ( Archived Site Source)
- Reused layout spacing from PDF template for visual consistency
- Added interactive_button partial